### PR TITLE
Configure models and API base from environment

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -214,12 +214,10 @@ async fn main() -> Result<(), ServerError> {
             documents_for_server = loaded_documents.clone();
 
             eprintln!("Generating embeddings...");
-            let (generated_embeddings, total_tokens) = generate_embeddings(
-                &openai_client,
-                &loaded_documents,
-                "text-embedding-3-small",
-            )
-            .await?;
+            let embedding_model: String = env::var("EMBEDDING_MODEL")
+                .unwrap_or_else(|_| "text-embedding-3-small".to_string());
+            let (generated_embeddings, total_tokens) =
+                generate_embeddings(&openai_client, &loaded_documents, &embedding_model).await?;
 
             let cost_per_million = 0.02;
             let estimated_cost = (total_tokens as f64 / 1_000_000.0) * cost_per_million;

--- a/src/server.rs
+++ b/src/server.rs
@@ -225,8 +225,10 @@ impl RustDocsServer {
                         doc.content, question
                     );
 
+                    let llm_model: String = env::var("LLM_MODEL")
+                        .unwrap_or_else(|_| "gpt-4o-mini-2024-07-18".to_string());
                     let chat_request = CreateChatCompletionRequestArgs::default()
-                        .model("gpt-4o-mini-2024-07-18")
+                        .model(llm_model)
                         .messages(vec![
                             ChatCompletionRequestSystemMessageArgs::default()
                                 .content(system_prompt)

--- a/src/server.rs
+++ b/src/server.rs
@@ -175,8 +175,10 @@ impl RustDocsServer {
             .get()
             .ok_or_else(|| McpError::internal_error("OpenAI client not initialized", None))?;
 
+        let embedding_model: String =
+            env::var("EMBEDDING_MODEL").unwrap_or_else(|_| "text-embedding-3-small".to_string());
         let question_embedding_request = CreateEmbeddingRequestArgs::default()
-            .model("text-embedding-3-small")
+            .model(embedding_model)
             .input(question.to_string())
             .build()
             .map_err(|e| {
@@ -379,5 +381,4 @@ impl ServerHandler for RustDocsServer {
             resource_templates: Vec::new(), // No templates defined yet
         })
     }
-
 }


### PR DESCRIPTION
Add the following env variables, defaulting to the previous values:
- `OPENAI_API_BASE`
- `EMBEDDING_MODEL`
- `LLM_MODEL`

This allows running via any OpenAI-compatible provider, including a local Ollama installation.