### PR TITLE
Add Ollama embedding/querying support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,7 +461,7 @@ dependencies = [
  "humantime",
  "ignore",
  "im-rc",
- "indexmap",
+ "indexmap 2.8.0",
  "itertools",
  "jobserver",
  "lazycell",
@@ -516,7 +538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b489cbdae63be32c040b5fe81b0f7725e563bcd805bb828e746971a4967aaf28"
 dependencies = [
  "cargo-credential",
- "security-framework",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -545,7 +567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527f6e2a4e80492e90628052be879a5996c2453ad5ec745bfa310a80b7eca20a"
 dependencies = [
  "anyhow",
- "core-foundation",
+ "core-foundation 0.10.0",
  "filetime",
  "hex",
  "ignore",
@@ -712,6 +734,16 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -2276,6 +2308,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -2449,6 +2487,22 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2668,6 +2722,17 @@ dependencies = [
  "sized-chunks",
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -3060,6 +3125,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3150,6 +3232,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ollama-rs"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5df54edb7e1264719be607cd40590d3769b5b35a2623e6e02681e6591aea5b8"
+dependencies = [
+ "async-stream",
+ "log",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "static_assertions",
+ "thiserror 2.0.12",
+ "url",
 ]
 
 [[package]]
@@ -3716,12 +3815,14 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3735,6 +3836,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -3863,7 +3965,7 @@ checksum = "781442f29170c5c93b7185ad559492601acdc71d5bb0706f5868094f45cfcd08"
 
 [[package]]
 name = "rustdocs_mcp_server"
-version = "1.1.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -3874,6 +3976,7 @@ dependencies = [
  "dotenvy",
  "futures",
  "ndarray",
+ "ollama-rs",
  "rmcp",
  "schemars",
  "scraper",
@@ -3883,6 +3986,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tiktoken-rs",
  "tokio",
+ "url",
  "walkdir",
  "xdg",
 ]
@@ -3948,7 +4052,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -4017,6 +4121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
+ "indexmap 1.9.3",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -4081,12 +4186,25 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4645,6 +4763,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4705,7 +4833,7 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap",
+ "indexmap 2.8.0",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.3.1"
 edition = "2024"
 
 [dependencies]
-rmcp = { version = "0.1.5", features = ["tower", "transport-io", "transport-sse-server", "macros", "server"] } # Add macros, server, schemars
+rmcp = { version = "0.1.5", features = ["tower", "transport-io", "transport-sse-server", "macros", "server"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 dotenvy = "0.15"
 serde = { version = "1", features = ["derive"] }
@@ -12,19 +12,18 @@ serde_json = "1"
 thiserror = "2.0.12"
 walkdir = "2.5.0"
 scraper = "0.23.1"
-ndarray = { version = "0.16.1", features = ["serde"] } # Enable serde feature
-async-openai = "0.28.0"
-# async-trait = "0.1.88" # Removed, likely no longer needed
+ndarray = { version = "0.16.1", features = ["serde"] }
+async-openai = "0.28.0"  # Keep for chat completion (optional)
+ollama-rs = "0.2.0"      # Add Ollama client
+url = "2.4"             # Add url parsing for Ollama client construction
 futures = "0.3"
-bincode = { version = "2.0.1", features = ["serde"] } # Enable serde integration
+bincode = { version = "2.0.1", features = ["serde"] }
 tiktoken-rs = "0.6.0"
-# Configure cargo crate to vendor openssl to avoid system mismatches
 cargo = { version = "0.87.1", default-features = false, features = ["vendored-openssl"] }
 tempfile = "3.19.1"
 anyhow = "1.0.97"
 schemars = "0.8.22"
 clap = { version = "4.5.34", features = ["cargo", "derive", "env"] }
-
 
 # --- Platform Specific Dependencies ---
 
@@ -34,12 +33,10 @@ xdg = { version = "2.5.2", features = ["serde"] }
 [target.'cfg(target_os = "windows")'.dependencies]
 dirs = "6.0.0"
 
-
 # Optimize release builds for size
 [profile.release]
-opt-level = "z"  # Optimize for size
-lto = true         # Enable Link Time Optimization
-codegen-units = 1  # Maximize size reduction opportunities
-panic = "abort"    # Abort on panic to remove unwinding code
-strip = true       # Strip symbols from binary
-
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = true

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -4,14 +4,18 @@ use async_openai::{
     Client as OpenAIClient,
 };
 use ndarray::{Array1, ArrayView1};
+use ollama_rs::{
+    generation::embeddings::request::GenerateEmbeddingsRequest,
+    Ollama,
+};
 use std::sync::OnceLock;
 use std::sync::Arc;
 use tiktoken_rs::cl100k_base;
 use futures::stream::{self, StreamExt};
 
-// Static OnceLock for the OpenAI client
+// Static OnceLocks for both clients
 pub static OPENAI_CLIENT: OnceLock<OpenAIClient<OpenAIConfig>> = OnceLock::new();
-
+pub static OLLAMA_CLIENT: OnceLock<Ollama> = OnceLock::new();
 
 use bincode::{Encode, Decode};
 use serde::{Serialize, Deserialize};
@@ -20,10 +24,9 @@ use serde::{Serialize, Deserialize};
 #[derive(Serialize, Deserialize, Debug, Encode, Decode)]
 pub struct CachedDocumentEmbedding {
     pub path: String,
-    pub content: String, // Add the extracted document content
+    pub content: String,
     pub vector: Vec<f32>,
 }
-
 
 /// Calculates the cosine similarity between two vectors.
 pub fn cosine_similarity(v1: ArrayView1<f32>, v2: ArrayView1<f32>) -> f32 {
@@ -38,60 +41,160 @@ pub fn cosine_similarity(v1: ArrayView1<f32>, v2: ArrayView1<f32>) -> f32 {
     }
 }
 
-/// Generates embeddings for a list of documents using the OpenAI API.
-pub async fn generate_embeddings(
-    client: &OpenAIClient<OpenAIConfig>,
+/// Generates embeddings using Ollama with the nomic-embed-text model
+pub async fn generate_ollama_embeddings(
+    ollama_client: &Ollama,
     documents: &[Document],
     model: &str,
-) -> Result<(Vec<(String, Array1<f32>)>, usize), ServerError> { // Return tuple: (embeddings, total_tokens)
-    // eprintln!("Generating embeddings for {} documents...", documents.len());
+) -> Result<Vec<(String, Array1<f32>)>, ServerError> {
+    eprintln!("Generating embeddings for {} documents using Ollama...", documents.len());
 
-    // Get the tokenizer for the model and wrap in Arc
+    const CONCURRENCY_LIMIT: usize = 4; // Lower concurrency for Ollama
+    const TOKEN_LIMIT: usize = 8000; // Adjust based on your model's limits
+
+    // Get the tokenizer (we'll use this for approximate token counting)
     let bpe = Arc::new(cl100k_base().map_err(|e| ServerError::Tiktoken(e.to_string()))?);
-
-    const CONCURRENCY_LIMIT: usize = 8; // Number of concurrent requests
-    const TOKEN_LIMIT: usize = 8000; // Keep a buffer below the 8192 limit
 
     let results = stream::iter(documents.iter().enumerate())
         .map(|(index, doc)| {
-            // Clone client, model, doc, and Arc<BPE> for the async block
-            let client = client.clone();
+            let ollama_client = ollama_client.clone();
             let model = model.to_string();
             let doc = doc.clone();
-            let bpe = Arc::clone(&bpe); // Clone the Arc pointer
+            let bpe = Arc::clone(&bpe);
 
             async move {
-                // Calculate token count for this document
+                // Approximate token count for filtering
                 let token_count = bpe.encode_with_special_tokens(&doc.content).len();
 
                 if token_count > TOKEN_LIMIT {
-                    // eprintln!(
-                    //     "    Skipping document {}: Actual tokens ({}) exceed limit ({}). Path: {}",
-                    //     index + 1,
-                    //     token_count,
-                    //     TOKEN_LIMIT,
-                    //     doc.path
-                    // );
-                    // Return Ok(None) to indicate skipping, with 0 tokens processed for this doc
-                    return Ok::<Option<(String, Array1<f32>, usize)>, ServerError>(None); // Include token count type
+                    eprintln!(
+                        "    Skipping document {}: Approximate tokens ({}) exceed limit ({}). Path: {}",
+                        index + 1,
+                        token_count,
+                        TOKEN_LIMIT,
+                        doc.path
+                    );
+                    return Ok::<Option<(String, Array1<f32>)>, ServerError>(None);
                 }
 
-                // Prepare input for this single document
+                eprintln!(
+                    "    Processing document {} (approx {} tokens)... Path: {}",
+                    index + 1,
+                    token_count,
+                    doc.path
+                );
+
+                // Create embeddings request for Ollama
+                let request = GenerateEmbeddingsRequest::new(
+                    model,
+                    doc.content.clone().into(),
+                );
+
+                match ollama_client.generate_embeddings(request).await {
+                    Ok(response) => {
+                        if let Some(embedding) = response.embeddings.first() {
+                            let embedding_array = Array1::from(embedding.clone());
+                            eprintln!("    Received response for document {}.", index + 1);
+                            Ok(Some((doc.path.clone(), embedding_array)))
+                        } else {
+                            Err(ServerError::Config(format!(
+                                "No embeddings returned for document {}",
+                                index + 1
+                            )))
+                        }
+                    }
+                    Err(e) => Err(ServerError::Config(format!(
+                        "Ollama embedding error for document {}: {}",
+                        index + 1, e
+                    )))
+                }
+            }
+        })
+        .buffer_unordered(CONCURRENCY_LIMIT)
+        .collect::<Vec<Result<Option<(String, Array1<f32>)>, ServerError>>>()
+        .await;
+
+    // Process collected results
+    let mut embeddings_vec = Vec::new();
+    for result in results {
+        match result {
+            Ok(Some((path, embedding))) => {
+                embeddings_vec.push((path, embedding));
+            }
+            Ok(None) => {} // Skipped document
+            Err(e) => {
+                eprintln!("Error during Ollama embedding generation: {}", e);
+                return Err(e);
+            }
+        }
+    }
+
+    eprintln!(
+        "Finished generating Ollama embeddings. Successfully processed {} documents.",
+        embeddings_vec.len()
+    );
+    Ok(embeddings_vec)
+}
+
+/// Generates embeddings for a single text using Ollama (for questions)
+pub async fn generate_single_ollama_embedding(
+    ollama_client: &Ollama,
+    text: &str,
+    model: &str,
+) -> Result<Array1<f32>, ServerError> {
+    let request = GenerateEmbeddingsRequest::new(
+        model.to_string(),
+        text.to_string().into(),
+    );
+
+    match ollama_client.generate_embeddings(request).await {
+        Ok(response) => {
+            if let Some(embedding) = response.embeddings.first() {
+                Ok(Array1::from(embedding.clone()))
+            } else {
+                Err(ServerError::Config("No embedding returned".to_string()))
+            }
+        }
+        Err(e) => Err(ServerError::Config(format!(
+            "Ollama embedding error: {}",
+            e
+        )))
+    }
+}
+
+/// Legacy OpenAI embedding generation (kept for fallback)
+pub async fn generate_openai_embeddings(
+    client: &OpenAIClient<OpenAIConfig>,
+    documents: &[Document],
+    model: &str,
+) -> Result<(Vec<(String, Array1<f32>)>, usize), ServerError> {
+    // Keep the original OpenAI implementation for fallback
+    let bpe = Arc::new(cl100k_base().map_err(|e| ServerError::Tiktoken(e.to_string()))?);
+
+    const CONCURRENCY_LIMIT: usize = 8;
+    const TOKEN_LIMIT: usize = 8000;
+
+    let results = stream::iter(documents.iter().enumerate())
+        .map(|(index, doc)| {
+            let client = client.clone();
+            let model = model.to_string();
+            let doc = doc.clone();
+            let bpe = Arc::clone(&bpe);
+
+            async move {
+                let token_count = bpe.encode_with_special_tokens(&doc.content).len();
+
+                if token_count > TOKEN_LIMIT {
+                    return Ok::<Option<(String, Array1<f32>, usize)>, ServerError>(None);
+                }
+
                 let inputs: Vec<String> = vec![doc.content.clone()];
-
                 let request = CreateEmbeddingRequestArgs::default()
-                    .model(&model) // Use cloned model string
+                    .model(&model)
                     .input(inputs)
-                    .build()?; // Propagates OpenAIError
+                    .build()?;
 
-                // eprintln!(
-                //     "    Sending request for document {} ({} tokens)... Path: {}",
-                //     index + 1,
-                //     token_count, // Use correct variable name
-                //     doc.path
-                // );
-                let response = client.embeddings().create(request).await?; // Propagates OpenAIError
-                // eprintln!("    Received response for document {}.", index + 1);
+                let response = client.embeddings().create(request).await?;
 
                 if response.data.len() != 1 {
                     return Err(ServerError::OpenAI(
@@ -107,39 +210,55 @@ pub async fn generate_embeddings(
                     ));
                 }
 
-                // Process result
-                let embedding_data = response.data.first().unwrap(); // Safe unwrap due to check above
+                let embedding_data = response.data.first().unwrap();
                 let embedding_array = Array1::from(embedding_data.embedding.clone());
-                // Return Ok(Some(...)) for successful embedding, include token count
-                Ok(Some((doc.path.clone(), embedding_array, token_count))) // Include token count
+                Ok(Some((doc.path.clone(), embedding_array, token_count)))
             }
         })
-        .buffer_unordered(CONCURRENCY_LIMIT) // Run up to CONCURRENCY_LIMIT futures concurrently
-        .collect::<Vec<Result<Option<(String, Array1<f32>, usize)>, ServerError>>>() // Update collected result type
+        .buffer_unordered(CONCURRENCY_LIMIT)
+        .collect::<Vec<Result<Option<(String, Array1<f32>, usize)>, ServerError>>>()
         .await;
 
-    // Process collected results, filtering out errors and skipped documents, summing tokens
     let mut embeddings_vec = Vec::new();
     let mut total_processed_tokens: usize = 0;
     for result in results {
         match result {
             Ok(Some((path, embedding, tokens))) => {
-                embeddings_vec.push((path, embedding)); // Keep successful embeddings
-                total_processed_tokens += tokens; // Add tokens for successful ones
+                embeddings_vec.push((path, embedding));
+                total_processed_tokens += tokens;
             }
-            Ok(None) => {} // Ignore skipped documents
+            Ok(None) => {}
             Err(e) => {
-                // Log error but potentially continue? Or return the first error?
-                // For now, let's return the first error encountered.
-                eprintln!("Error during concurrent embedding generation: {}", e);
+                eprintln!("Error during OpenAI embedding generation: {}", e);
                 return Err(e);
             }
         }
     }
 
     eprintln!(
-        "Finished generating embeddings. Successfully processed {} documents ({} tokens).",
+        "Finished generating OpenAI embeddings. Successfully processed {} documents ({} tokens).",
         embeddings_vec.len(), total_processed_tokens
     );
-    Ok((embeddings_vec, total_processed_tokens)) // Return tuple
+    Ok((embeddings_vec, total_processed_tokens))
+}
+
+/// Main embedding generation function that tries Ollama first, falls back to OpenAI
+pub async fn generate_embeddings(
+    documents: &[Document],
+    model: &str,
+) -> Result<(Vec<(String, Array1<f32>)>, usize), ServerError> {
+    // Check if Ollama is available
+    if let Some(ollama_client) = OLLAMA_CLIENT.get() {
+        eprintln!("Using Ollama for embedding generation with model: {}", model);
+        // For Ollama, we don't track tokens the same way, so return 0 for token count
+        let embeddings = generate_ollama_embeddings(ollama_client, documents, model).await?;
+        Ok((embeddings, 0))
+    } else if let Some(openai_client) = OPENAI_CLIENT.get() {
+        eprintln!("Fallback to OpenAI for embedding generation with model: {}", model);
+        generate_openai_embeddings(openai_client, documents, model).await
+    } else {
+        Err(ServerError::Config(
+            "No embedding client available (neither Ollama nor OpenAI)".to_string()
+        ))
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,25 +1,25 @@
-use rmcp::ServiceError; // Assuming ServiceError is the correct top-level error
+use rmcp::ServiceError;
 use thiserror::Error;
-use crate::doc_loader::DocLoaderError; // Need to import DocLoaderError from the sibling module
+use crate::doc_loader::DocLoaderError;
 
 #[derive(Debug, Error)]
 pub enum ServerError {
     #[error("Environment variable not set: {0}")]
     MissingEnvVar(String),
-    // MissingArgument removed as clap handles this now
     #[error("Configuration Error: {0}")]
     Config(String),
-
     #[error("MCP Service Error: {0}")]
-    Mcp(#[from] ServiceError), // Use ServiceError
+    Mcp(#[from] ServiceError),
     #[error("IO Error: {0}")]
     Io(#[from] std::io::Error),
     #[error("Document Loading Error: {0}")]
     DocLoader(#[from] DocLoaderError),
     #[error("OpenAI Error: {0}")]
     OpenAI(#[from] async_openai::error::OpenAIError),
+    #[error("Ollama Error: {0}")]
+    Ollama(#[from] ollama_rs::error::OllamaError), // Add Ollama error handling
     #[error("JSON Error: {0}")]
-    Json(#[from] serde_json::Error), // Add error for JSON deserialization
+    Json(#[from] serde_json::Error),
     #[error("Tiktoken Error: {0}")]
     Tiktoken(String),
     #[error("XDG Directory Error: {0}")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use std::{
     io::BufReader,
     path::PathBuf,
 };
-use url; // Add url crate for URL parsing
+// Removed unused url import
 #[cfg(not(target_os = "windows"))]
 use xdg::BaseDirectories;
 


### PR DESCRIPTION
Needed to add Ollama for my usage/implementation so I added support for embedding/querying with local Ollama models. Currently uses `nomic-embed-text` (https://ollama.com/library/nomic-embed-text) and `llama3.2` models for embedding/querying respectively. This can be adapted to be passed as an argument for custom models selection but for my purposes I only needed these 2 models specifically.

Tested with Claude desktop and working.