### PR TITLE
feat(server): implement async tool handling and dynamic tool listing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ doc
 debug/
 storage/
 .roo/
+
+# claude
+.mcp.json


### PR DESCRIPTION
the tool name now will be the same as the crate name

this would fix #8 

the tool name is now query_{crate}_docs

this was done by removing the tool macro at server.rs:288 and implementing tool_call and list_tools manually.


- **note this code was generated by ai. if you dont want ai code in your repo do not accept this pull request**
