### PR TITLE
feat: add a multi-crate mode

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -52,12 +52,11 @@ pub async fn generate_embeddings(
     const CONCURRENCY_LIMIT: usize = 8; // Number of concurrent requests
     const TOKEN_LIMIT: usize = 8000; // Keep a buffer below the 8192 limit
 
-    let results = stream::iter(documents.iter().enumerate())
+    let results = stream::iter(documents.iter().enumerate().map(|(i, d)| (i, d.clone())).collect::<Vec<_>>())
         .map(|(index, doc)| {
             // Clone client, model, doc, and Arc<BPE> for the async block
             let client = client.clone();
             let model = model.to_string();
-            let doc = doc.clone();
             let bpe = Arc::clone(&bpe); // Clone the Arc pointer
 
             async move {


### PR DESCRIPTION
When no argument is passed on the command line, the server runs in a secondary mode that allows the LLM to pass the crate name it wants to ask about with each request.

Full disclosure: this was mostly written by claude opus 4.1. Seems to work. I also have a commit with some integration tests written by claude. I didn't want to submit them together, but can add them here or in another PR if you want.